### PR TITLE
Solution for better error messages when using iron with upickle

### DIFF
--- a/src/main/scala/toto/endpoints.scala
+++ b/src/main/scala/toto/endpoints.scala
@@ -5,12 +5,13 @@ import sttp.tapir.*
 import sttp.tapir.json.pickler.jsonBody
 import toto.model.*
 import toto.picklers.given
+import toto.util.iron.ironJsonBody
 
 object endpoints:
 
   val ironToto = endpoint.post
     .in("toto" / "iron")
-    .in(jsonBody[IronToto])
+    .in(ironJsonBody[IronToto])
     .out(emptyOutput)
 
   val vanillaToto = endpoint.post

--- a/src/main/scala/toto/util/iron.scala
+++ b/src/main/scala/toto/util/iron.scala
@@ -1,0 +1,36 @@
+package toto.util
+
+import sttp.tapir.Codec.JsonCodec
+import sttp.tapir.CodecFormat.Json
+import sttp.tapir.DecodeResult.Error.JsonDecodeException
+import sttp.tapir.json.pickler.Pickler
+import sttp.tapir.{DecodeResult, EndpointIO, Schema, ValidationError, stringBodyUtf8AnyFormat}
+
+object iron {
+
+  case class IronException(originalValue: Any, errorMessage: String) extends Exception
+
+  def ironJsonBody[T: Pickler]: EndpointIO.Body[String, T] = stringBodyUtf8AnyFormat(new IronCodec(summon[Pickler[T]].toCodec))
+
+  /**
+   * Custom codec for body containing iron-constrainted types. This is necessary to change decoding `Error`
+   * into `InvalidValue` based on custom exception
+   *
+   * @param delegate delegate `Codec` for the same type `T` throwing `Error` with wrapped custom exception
+   */
+  class IronCodec[T](delegate: JsonCodec[T]) extends JsonCodec[T] {
+    override def rawDecode(l: String): DecodeResult[T] = delegate.rawDecode(l) match {
+      case DecodeResult.Error(_, JsonDecodeException(_, IronException(originalValue, errorMessage))) =>
+        DecodeResult.InvalidValue(List(ValidationError(null, originalValue, List(), Some(errorMessage))))
+      case other =>
+        other
+    }
+
+    override def encode(h: T): String = delegate.encode(h)
+
+    override def schema: Schema[T] = delegate.schema
+
+    override def format: Json = delegate.format
+  }
+
+}

--- a/src/main/scala/toto/util/upickle.scala
+++ b/src/main/scala/toto/util/upickle.scala
@@ -1,8 +1,8 @@
 package toto.util
 
-import _root_.upickle.core.Abort
 import _root_.upickle.default.*
 import io.github.iltotore.iron.{:|, Constraint, RefinedTypeOps, refineEither}
+import toto.util.iron.IronException
 
 /**
  * Implicit `Reader`s and `Writer`s for iron types using uPickle.
@@ -11,6 +11,8 @@ object upickle:
 
   /**
    * A `Reader` for refined types using uPickle. Decodes to the underlying type then checks the constraint.
+   * Throws custom `IronException` in case of failure to be later handled by Codec`
+   * to return `DecodingResult.InvalidValue` instead of `DecodeResult.Error`
    *
    * @param reader the `Reader` of the underlying type.
    * @param constraint the `Constraint` implementation to test the decoded value.
@@ -19,7 +21,7 @@ object upickle:
     reader.map(value =>
       value.refineEither match {
         case Right(refinedValue) => refinedValue
-        case Left(errorMessage) => throw Abort(errorMessage)
+        case Left(errorMessage) => throw IronException(value, errorMessage)
       }
     )
 


### PR DESCRIPTION
Hello,

This is some solution for your problem. It is based on custom exception thrown in case of failed `iron` refinement. From generic `Codec` point of view this is `Error` - undistinguishable from e.g. corrupted JSON. We have to use custom exception in `Reader` and then match it in custom `Codec` to know it is not corrupted JSON and not decoding error of that kind but validation error. Exception is matched and `Error` is changed to `InvalidValue`. The only part missing is `path`. To have it we need to create it in `Reader` but it seems like we don't have all the necessary knowledge there.

Hope this hepls! Happy coding with tAPIr!