### PR TITLE
Better error message with custom `IronException` and `decodeFailureHandler`

### DIFF
--- a/src/main/scala/toto/App.scala
+++ b/src/main/scala/toto/App.scala
@@ -7,15 +7,37 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 import com.comcast.ip4s.*
 import org.http4s.ember.server.EmberServerBuilder
 import org.typelevel.log4cats.Logger
-import sttp.tapir.server.http4s.Http4sServerInterpreter
+import sttp.tapir.server.http4s.{Http4sServerInterpreter, Http4sServerOptions}
 import org.http4s.implicits.*
+import sttp.tapir.DecodeResult
+import sttp.tapir.DecodeResult.Error
+import sttp.tapir.DecodeResult.Error.JsonDecodeException
+import sttp.tapir.server.interceptor.DecodeFailureContext
+import sttp.tapir.server.interceptor.decodefailure.DefaultDecodeFailureHandler.{FailureMessages, default}
+import sttp.tapir.server.interceptor.decodefailure.DefaultDecodeFailureHandler
 import sttp.tapir.swagger.bundle.SwaggerInterpreter
+import toto.util.IronException
 
 object App extends IOApp.Simple:
 
   given Logger[IO] = Slf4jLogger.getLogger[IO]
 
-  val ironRoute = Http4sServerInterpreter[IO]().toRoutes(endpoints.ironToto.serverLogic(toto=>{
+  def failureDetailMessage(failure: DecodeResult.Failure): Option[String] = failure match {
+    case Error(_, JsonDecodeException(errors, IronException(originalValue, errorMessage))) =>
+      Some(s"Failed to parse value $originalValue. Error: $errorMessage. Json errors: ${errors}")
+    case other => FailureMessages.failureDetailMessage(other)
+  }
+
+  def failureMessage(ctx: DecodeFailureContext): String = {
+    val base = FailureMessages.failureSourceMessage(ctx.failingInput)
+    val detail = failureDetailMessage(ctx.failure)
+    FailureMessages.combineSourceAndDetail(base, detail)
+  }
+
+  val handler = new DefaultDecodeFailureHandler(default.respond, failureMessage, default.response)
+  val serverOptions: Http4sServerOptions[IO] = Http4sServerOptions.customiseInterceptors[IO].decodeFailureHandler(handler).options
+
+  val ironRoute = Http4sServerInterpreter[IO](serverOptions).toRoutes(endpoints.ironToto.serverLogic(toto=>{
     Logger[IO].info("received message with iron toto")
     IO.pure(().asRight)
   }))

--- a/src/main/scala/toto/util/IronException.scala
+++ b/src/main/scala/toto/util/IronException.scala
@@ -1,0 +1,4 @@
+package toto.util
+
+case class IronException(originalValue: Any, errorMessage: String) extends Exception
+

--- a/src/main/scala/toto/util/upickle.scala
+++ b/src/main/scala/toto/util/upickle.scala
@@ -1,6 +1,5 @@
 package toto.util
 
-import _root_.upickle.core.Abort
 import _root_.upickle.default.*
 import io.github.iltotore.iron.{:|, Constraint, RefinedTypeOps, refineEither}
 
@@ -19,7 +18,7 @@ object upickle:
     reader.map(value =>
       value.refineEither match {
         case Right(refinedValue) => refinedValue
-        case Left(errorMessage) => throw Abort(errorMessage)
+        case Left(errorMessage) => throw IronException(value, errorMessage)
       }
     )
 


### PR DESCRIPTION
Another solution for iron-pickler problem :) This time we don't create custom `Codec` but customise error handling instead.